### PR TITLE
Copy to http/smb depending on the context

### DIFF
--- a/ai-deploy-cluster-remoteworker/inventory/hosts.sample
+++ b/ai-deploy-cluster-remoteworker/inventory/hosts.sample
@@ -35,6 +35,7 @@ bmc_password="ADMIN"
 # Only use smb config with SuperMicro as it does not support HTTP server for ISO images hosts
 smb_host=192.168.111.1
 smb_path=share
+smb_server_path=/path/to/samba/share # only if virtualmedia uses smb mounts
 bridge_name=nm-bridge
 libvirt_uri="qemu:///system"
 

--- a/ai-deploy-cluster-remoteworker/roles/create-cluster-day2/tasks/main.yml
+++ b/ai-deploy-cluster-remoteworker/roles/create-cluster-day2/tasks/main.yml
@@ -20,8 +20,6 @@
     - name: And download it
       shell: "aicli download iso {{ cluster_name }}-day2 -p {{ ai_iso_path }}"
 
-    - name: Copy AI ISO to HTTP Server
-      shell: "cp {{ ai_iso_path }}/{{ cluster_name }}-day2.iso {{ http_server_path }}"
   environment:
     AI_URL: "{{ ai_url }}"
 

--- a/ai-deploy-cluster-remoteworker/roles/modify-iso-day2/tasks/main.yml
+++ b/ai-deploy-cluster-remoteworker/roles/modify-iso-day2/tasks/main.yml
@@ -35,6 +35,7 @@
     chdir: "{{ script_directory.path }}"
     cmd: "{{ script_directory.path }}/inject_config_files.sh {{ small_iso_path }} {{ final_iso_path }} {{ ignition_url }} {{ rootfs_url }} {% if kernel_arguments is defined %}'{{ kernel_arguments }}'{% else %}''{% endif %} {% if ramdisk_path is defined %}{{ script_directory.path }}/extra_config.img{% else %}''{%  endif %}"
 
-- name: Copy final ISO to HTTP Server
-  shell: "cp {{ final_iso_path }} {{ http_server_path }}"
+- name: Copy final ISO to SMB/HTTP Server
+  shell: "cp {{ final_iso_path }} {% if smb_server_path is defined and smb_server_path %}{{ smb_server_path }}{% else %}{{ http_server_path }}{% endif %}"
+  ignore_errors: true
 

--- a/ai-deploy-cluster-remoteworker/roles/prepare-environment/tasks/main.yml
+++ b/ai-deploy-cluster-remoteworker/roles/prepare-environment/tasks/main.yml
@@ -89,9 +89,6 @@
     chdir: "{{ script_directory.path }}"
     cmd: "{{ script_directory.path }}/generate_rhcos_iso.sh {{ small_iso_path }}"
 
-- name: Copy small ISO to HTTP Server
-  shell: "cp {{ small_iso_path }} {{ http_server_path }}"
-
 - name: Clone the assisted installer project
   git:
     repo: 'https://github.com/openshift/assisted-service'


### PR DESCRIPTION
When we use http for virtualmedia, small ISO needs
to be copied there. But for samba this small ISO
needs to be copied to the smb share path.