### PR TITLE
Update host names on master nodes

### DIFF
--- a/ai-deploy-cluster-remoteworker/roles/deploy-cluster/tasks/main.yml
+++ b/ai-deploy-cluster-remoteworker/roles/deploy-cluster/tasks/main.yml
@@ -25,6 +25,13 @@
     - name: Install cluster
       shell: "aicli start cluster {{ cluster_name }}"
 
+    - name: Update Hosts names
+      shell: "aicli update host $(aicli list hosts | grep {{ cluster_name }} | awk 'NR == {{ item }} {print $6}') -P hostname=master_{{ item }}.{{ cluster_name }}.{{ cluster_domain }}"
+      with_items:
+        - 1
+        - 2
+        - 3
+
     - name: Wait until cluster is installed
       shell: "aicli list cluster | grep {{ cluster_name }} |  cut -d '|' -f4 | tr -d ' '"
       register: cluster_ready


### PR DESCRIPTION
Force the hostname in all master nodes, so they take the
one needed without relying on external dhcp

Signed-off-by: Yolanda Robla <yroblamo@redhat.com>