### PR TITLE
Get http url from config file

### DIFF
--- a/ai-deploy-cluster-remoteworker/inventory/hosts.sample
+++ b/ai-deploy-cluster-remoteworker/inventory/hosts.sample
@@ -16,7 +16,8 @@ rootfs_url=https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/4.6/
 
 # should be same as the installer machine IP-address
 ai_url="http://192.168.112.199:8080"
-ignition_url=http://192.168.112.199/
+ignition_url="http://192.168.112.199"
+iso_url="http://192.168.112.199"
 
 # You will need to configure your env DNS server for the cluster_domain and cluster_name
 cluster_name="test-aut"

--- a/ai-deploy-cluster-remoteworker/roles/add-remote-workers/tasks/add_remote_worker.yaml
+++ b/ai-deploy-cluster-remoteworker/roles/add-remote-workers/tasks/add_remote_worker.yaml
@@ -100,5 +100,6 @@
       mode: 700
 
   - name: run racadm
-    shell: "/root/racadm.sh {{ hostvars[item].bmc_user }} {{ hostvars[item].bmc_password }} {{ hostvars[item].bmc_address }} {{ item }}.iso"
-  when: hostvars[item].bmc_type == "Dell" and (host_exist.stdout|int == 0 or hostvars[item].redeploy|bool == true)
+    shell: "/root/racadm.sh {{ hostvars[item].bmc_user }} {{ hostvars[item].bmc_password }} {{ hostvars[item].bmc_address }} {{ iso_url }} {{ item }}.iso"
+  when: hostvars[item].bmc_type == "Dell"
+

--- a/ai-deploy-cluster-remoteworker/roles/add-remote-workers/templates/racadm.sh
+++ b/ai-deploy-cluster-remoteworker/roles/add-remote-workers/templates/racadm.sh
@@ -1,8 +1,9 @@
 USER=$1
 PASSWORD=$2
 SERVER=$3
-ISO_PATH=$4
-ISO_URL="http://$(hostname -I | cut -f2 -d" " | xargs)/$ISO_PATH"
+HTTP_URL=$4
+ISO_PATH=$5
+ISO_URL="$HTTP_URL/$ISO_PATH"
 /opt/dell/srvadmin/bin/idracadm7 -r $SERVER -u $USER -p $PASSWORD remoteimage -s &&\
 /opt/dell/srvadmin/bin/idracadm7 -r $SERVER -u $USER -p $PASSWORD remoteimage -d &&\
 /opt/dell/srvadmin/bin/idracadm7 -r $SERVER -u $USER -p $PASSWORD remoteimage -c -l $ISO_URL &&\


### PR DESCRIPTION
hostname command may return wrong ip address on a server with several network interfaces. Switched for using value from config instead of hardcoded hostname command.