### PR TITLE
Pass the cluster settings when deploying day2

### DIFF
--- a/ai-deploy-cluster-remoteworker/roles/create-cluster-day2/tasks/main.yml
+++ b/ai-deploy-cluster-remoteworker/roles/create-cluster-day2/tasks/main.yml
@@ -12,7 +12,7 @@
 - name: Create cluster and download ISO
   block:
     - name: Create new AI cluster
-      shell: "aicli create cluster  {{ cluster_name }}-day2"
+      shell: "aicli create cluster -P pull_secret={{ tempfile_pullsecret.path }} -P base_dns_domain={{ cluster_domain }} -P ssh_public_key='{{ ssh_public_key }}' {{ cluster_name }}-day2"
 
     - name: Generate the ISO for the cluster
       shell: "aicli create iso -P ssh_public_key='{{ ssh_public_key }}' {{ cluster_name }}-day2"

--- a/ai-deploy-cluster-remoteworker/roles/deploy-cluster-day2/tasks/main.yml
+++ b/ai-deploy-cluster-remoteworker/roles/deploy-cluster-day2/tasks/main.yml
@@ -1,9 +1,6 @@
 ---
 - name: Configure cluster
   block:
-    - name: Set API VIP
-      shell: "aicli update cluster -P api_vip={{ api_vip }} {{ cluster_name }}-day2"
-
     - name: Update host to copy the network
       shell: "aicli update host $(aicli list hosts | grep {{ cluster_name }} | grep {{ item }} | awk '{print $6}') -P extra_args=[--copy-network]"
       with_items: "{{ groups['worker_nodes'] }}"


### PR DESCRIPTION
This allows to just add remote worker nodes on an
existing cluster, without needing to have the da1
cluster into AI.

Signed-off-by: Yolanda Robla <yroblamo@redhat.com>