### PR TITLE
Add the ability to specify openshift version

### DIFF
--- a/ai-deploy-cluster-remoteworker/inventory/hosts.sample
+++ b/ai-deploy-cluster-remoteworker/inventory/hosts.sample
@@ -22,6 +22,7 @@ ignition_url=http://192.168.112.199/
 # You will need to configure your env DNS server for the cluster_domain and cluster_name
 cluster_name="test-aut"
 cluster_domain="cluster.testing"
+cluster_version="4.7"
 
 # Make sure api_vip is mapped in your env DNS server to api.{cluster_name}.{cluster_domain} AND ingress_vip to *.apps.{cluster_name}.{cluster_domain}
 ingress_vip=192.168.112.195

--- a/ai-deploy-cluster-remoteworker/roles/create-cluster-day2/tasks/main.yml
+++ b/ai-deploy-cluster-remoteworker/roles/create-cluster-day2/tasks/main.yml
@@ -12,7 +12,7 @@
 - name: Create cluster and download ISO
   block:
     - name: Create new AI cluster
-      shell: "aicli create cluster -P pull_secret={{ tempfile_pullsecret.path }} -P base_dns_domain={{ cluster_domain }} -P ssh_public_key='{{ ssh_public_key }}' {{ cluster_name }}-day2"
+      shell: "aicli create cluster -P pull_secret={{ tempfile_pullsecret.path }} -P base_dns_domain={{ cluster_domain }} -P ssh_public_key='{{ ssh_public_key }}' -P openshift_version='{{ cluster_version }}' {{ cluster_name }}-day2"
 
     - name: Generate the ISO for the cluster
       shell: "aicli create iso -P ssh_public_key='{{ ssh_public_key }}' {{ cluster_name }}-day2"

--- a/ai-deploy-cluster-remoteworker/roles/create-cluster/tasks/main.yml
+++ b/ai-deploy-cluster-remoteworker/roles/create-cluster/tasks/main.yml
@@ -12,7 +12,7 @@
 - name: Create cluster and download ISO
   block:
     - name: Create new AI cluster
-      shell: "aicli create cluster -P pull_secret={{ tempfile_pullsecret.path }} -P base_dns_domain={{ cluster_domain }} -P ssh_public_key='{{ ssh_public_key }}' -P ingress_vip={{ ingress_vip }} {{ cluster_name }}"
+      shell: "aicli create cluster -P pull_secret={{ tempfile_pullsecret.path }} -P base_dns_domain={{ cluster_domain }} -P ssh_public_key='{{ ssh_public_key }}' -P ingress_vip={{ ingress_vip }} -P openshift_version="{{ cluster_version }}" {{ cluster_name }}"
       retries: 30
       delay: 5
       register: result


### PR DESCRIPTION
Add a new cluster_version setting, that allows to specify
the version of the cluster to install. By default is set
to 4.7

Signed-off-by: Yolanda Robla <yroblamo@redhat.com>