### PR TITLE
Modify playbook to be run from any host

### DIFF
--- a/ai-deploy-cluster-remoteworker/README.md
+++ b/ai-deploy-cluster-remoteworker/README.md
@@ -6,6 +6,7 @@ and Small ISO.
     - Podman.
     - Ansible.
         - Ansible modules: community.libvirt, containers.podman and community.general
+          You can install all the requirements with: `ansible-galaxy collection install -r requirements.yaml`
 
 - Steps:
 

--- a/ai-deploy-cluster-remoteworker/inventory/hosts.sample
+++ b/ai-deploy-cluster-remoteworker/inventory/hosts.sample
@@ -22,6 +22,7 @@ ignition_url=http://192.168.112.199/
 # You will need to configure your env DNS server for the cluster_domain and cluster_name
 cluster_name="test-aut"
 cluster_domain="cluster.testing"
+cluster_version="4.7"
 
 # Make sure api_vip is mapped in your env DNS server to api.{cluster_name}.{cluster_domain} AND ingress_vip to *.apps.{cluster_name}.{cluster_domain}
 ingress_vip=192.168.112.195
@@ -34,6 +35,7 @@ need_racadm=true
 [provisioner]
 # host from where the installation is performed
 localhost ansible_connection=local
+#<remote_ip> ansible_connection=ssh
 
 [worker_nodes]
 worker-0.test-aut.cluster-testing bmc_type=SuperMicro bmc_address=192.168.111.212 bmc_user="ADMIN" bmc_password="ADMIN" smb_host=192.168.111.1 smb_path=share smb_server_path=/home/share ramdisk_path=/opt/network-config kernel_arguments="" final_iso_path=/home/share/ ignition_name=worker0

--- a/ai-deploy-cluster-remoteworker/playbook.yml
+++ b/ai-deploy-cluster-remoteworker/playbook.yml
@@ -1,23 +1,33 @@
 ---
 - name: Deploy clusters with assisted installer
   hosts: provisioner
+  environment:
+    PATH: "/usr/bin/:/usr/local/bin/:{{ ansible_env.PATH }}"
   roles:
     - role: prepare-environment
       tags: prepare-environment
+      become: yes
     - role: create-cluster
       tags: create-cluster
+      become: yes
     - role: enroll-hosts
       tags: enroll-hosts
+      become: yes
     - role: deploy-cluster
       tags: deploy-cluster
+      become: yes
     - role: expose-endpoints
       tags: expose-endpoints
+      become: yes
     - role: create-cluster-day2
       tags: create-cluster-day2
+      become: yes
     - role: modify-iso-day2
       tags: modify-iso-day2
+      become: yes
     - role: add-remote-workers
       tags: add-remote-workers
+      become: yes
     - role: deploy-cluster-day2
       tags: deploy-cluster-day2
-
+      become: yes

--- a/ai-deploy-cluster-remoteworker/requirements.yml
+++ b/ai-deploy-cluster-remoteworker/requirements.yml
@@ -1,0 +1,5 @@
+---
+collections:
+  - name: community.libvirt
+  - name: containers.podman
+  - name: community.general

--- a/ai-deploy-cluster-remoteworker/roles/create-cluster-day2/tasks/main.yml
+++ b/ai-deploy-cluster-remoteworker/roles/create-cluster-day2/tasks/main.yml
@@ -12,7 +12,7 @@
 - name: Create cluster and download ISO
   block:
     - name: Create new AI cluster
-      shell: "aicli create cluster -P pull_secret={{ tempfile_pullsecret.path }} -P base_dns_domain={{ cluster_domain }} -P ssh_public_key='{{ ssh_public_key }}' {{ cluster_name }}-day2"
+      shell: "aicli create cluster -P pull_secret={{ tempfile_pullsecret.path }} -P base_dns_domain={{ cluster_domain }} -P ssh_public_key='{{ ssh_public_key }}' -P openshift_version='{{ cluster_version }}' {{ cluster_name }}-day2"
 
     - name: Generate the ISO for the cluster
       shell: "aicli create iso -P ssh_public_key='{{ ssh_public_key }}' {{ cluster_name }}-day2"

--- a/ai-deploy-cluster-remoteworker/roles/create-cluster/tasks/main.yml
+++ b/ai-deploy-cluster-remoteworker/roles/create-cluster/tasks/main.yml
@@ -12,7 +12,7 @@
 - name: Create cluster and download ISO
   block:
     - name: Create new AI cluster
-      shell: "aicli create cluster -P pull_secret={{ tempfile_pullsecret.path }} -P base_dns_domain={{ cluster_domain }} -P ssh_public_key='{{ ssh_public_key }}' -P ingress_vip={{ ingress_vip }} {{ cluster_name }}"
+      shell: "aicli create cluster -P pull_secret={{ tempfile_pullsecret.path }} -P base_dns_domain={{ cluster_domain }} -P ssh_public_key='{{ ssh_public_key }}' -P ingress_vip={{ ingress_vip }} -P openshift_version='{{ cluster_version }}' {{ cluster_name }}"
       retries: 30
       delay: 5
       register: result

--- a/ai-deploy-cluster-remoteworker/roles/expose-endpoints/templates/haproxy.cfg.j2
+++ b/ai-deploy-cluster-remoteworker/roles/expose-endpoints/templates/haproxy.cfg.j2
@@ -4,8 +4,6 @@ global
     chroot      /var/lib/haproxy
     pidfile     /var/run/haproxy.pid
     maxconn     4000
-    user        {{ ansible_user }}
-    group       {{ ansible_user }}
     daemon
 
 defaults

--- a/ai-deploy-cluster-remoteworker/roles/modify-iso-day2/tasks/main.yml
+++ b/ai-deploy-cluster-remoteworker/roles/modify-iso-day2/tasks/main.yml
@@ -8,16 +8,19 @@
   get_url:
       url: https://raw.githubusercontent.com/redhat-ztp/ztp-iso-generator/main/rhcos-iso/inject_config_files.sh
       dest: "{{ script_directory.path }}/inject_config_files.sh"
+      mode: 0755
 
 - name: Get the script to generate ramdisk
   get_url:
       url: https://raw.githubusercontent.com/redhat-ztp/ztp-iso-generator/main/rhcos-iso/ramdisk_generator.sh
       dest: "{{ script_directory.path }}/ramdisk_generator.sh"
+      mode: 0755
 
 - name: Get the script to extract ignition from ISO
   get_url:
       url: https://raw.githubusercontent.com/redhat-ztp/ztp-iso-generator/main/rhcos-iso/extract_ignition_from_ai_iso.sh
       dest: "{{ script_directory.path }}/extract_ignition_from_ai_iso.sh"
+      mode: 0755
 
 - name: Create temporary directory for modifying the ignition
   tempfile:
@@ -25,7 +28,7 @@
   register: ignition_directory
 
 - name: Extract the ignition file from the downloaded ISO
-  script:
+  shell:
     chdir: "{{ script_directory.path }}"
     cmd: "{{ script_directory.path }}/extract_ignition_from_ai_iso.sh {{ ai_iso_path }}/{{ cluster_name }}-day2.iso {{ http_server_path }}/ai_ignition"
 

--- a/ai-deploy-cluster-remoteworker/roles/modify-iso-day2/tasks/modify_iso_for_worker.yaml
+++ b/ai-deploy-cluster-remoteworker/roles/modify-iso-day2/tasks/modify_iso_for_worker.yaml
@@ -9,6 +9,7 @@
     copy:
       src: "{{ http_server_path }}/ai_ignition"
       dest: "{{ ignition_directory.path }}/{{ hostvars[item].ignition_name }}"
+      remote_src: yes
 
   - name: Copy network directory to the ignition temporary path, if we need to inject it
     copy:
@@ -17,7 +18,7 @@
       mode: preserve
 
   - name: Generate extra ramdisk
-    script:
+    shell:
       chdir: "{{ script_directory.path }}"
       cmd: "{{ script_directory.path }}/ramdisk_generator.sh {{ hostvars[item].ramdisk_path }} {{ script_directory.path }}/extra_config.img"
 
@@ -28,10 +29,11 @@
     copy:
       src: "{{ ignition_directory.path }}/modified_ignition"
       dest: "{{ http_server_path }}/{{ hostvars[item].ignition_name }}"
+      remote_src: yes
   when: hostvars[item].ramdisk_path is defined
 
 - name: Produce the final iso
-  script:
+  shell:
     chdir: "{{ script_directory.path }}"
     cmd: "{{ script_directory.path }}/inject_config_files.sh {{ small_iso_path }} {{ hostvars[item].final_iso_path }}/{{ item }}.iso {{ ignition_url }}/{{ hostvars[item].ignition_name }} {{ rootfs_url }} {% if hostvars[item].kernel_arguments is defined %}'{{ hostvars[item].kernel_arguments }}'{% else %}''{% endif %} {% if hostvars[item].ramdisk_path is defined %}{{ script_directory.path }}/extra_config.img{% else %}''{%  endif %}"
 

--- a/ai-deploy-cluster-remoteworker/roles/prepare-environment/tasks/main.yml
+++ b/ai-deploy-cluster-remoteworker/roles/prepare-environment/tasks/main.yml
@@ -72,9 +72,10 @@
   get_url:
       url: https://raw.githubusercontent.com/redhat-ztp/ztp-iso-generator/main/rhcos-iso/generate_rhcos_iso.sh
       dest: "{{ script_directory.path }}/generate_rhcos_iso.sh"
+      mode: 0755
 
 - name: Create the small ISO and copy to desired path
-  script:
+  shell:
     chdir: "{{ script_directory.path }}"
     cmd: "{{ script_directory.path }}/generate_rhcos_iso.sh {{ small_iso_path }}"
 


### PR DESCRIPTION
Currently the playbook had only been tested
running from localhost. But shold be possible to run
remotely, by specifying an ip on the provisioner inventory
entry.
Several changes have been needed in order to make it
run from any server.

Signed-off-by: Yolanda Robla <yroblamo@redhat.com>