### PR TITLE
Get rid of small iso path

### DIFF
--- a/ai-deploy-cluster-remoteworker/inventory/hosts.sample
+++ b/ai-deploy-cluster-remoteworker/inventory/hosts.sample
@@ -9,7 +9,6 @@ ssh_public_key="ssh-rsa xxx"
 # Default as httpd config
 ignition_http_server_path=/var/www/html
 kernel_arguments=""
-small_iso_path=/opt/cached_disconnected_images/small_iso.iso
 ai_iso_path=/opt/cached_disconnected_images
 
 # You can set your own rootfs image and store it under the same IP as above.

--- a/ai-deploy-cluster-remoteworker/roles/modify-iso-day2/tasks/modify_iso_for_worker.yaml
+++ b/ai-deploy-cluster-remoteworker/roles/modify-iso-day2/tasks/modify_iso_for_worker.yaml
@@ -35,5 +35,5 @@
 - name: Produce the final iso
   shell:
     chdir: "{{ script_directory.path }}"
-    cmd: "{{ script_directory.path }}/inject_config_files.sh {{ small_iso_path }} {{ hostvars[item].final_iso_path }}/{{ item }}.iso {{ ignition_url }}/{{ hostvars[item].ignition_name }} {{ rootfs_url }} {% if hostvars[item].kernel_arguments is defined %}'{{ hostvars[item].kernel_arguments }}'{% else %}''{% endif %} {% if hostvars[item].ramdisk_path is defined %}{{ script_directory.path }}/extra_config.img{% else %}''{%  endif %}"
+    cmd: "{{ script_directory.path }}/inject_config_files.sh {{ temporary_directory }}/small_{{ cluster_name }}.iso {{ hostvars[item].final_iso_path }}/{{ item }}.iso {{ ignition_url }}/{{ hostvars[item].ignition_name }} {{ rootfs_url }} {% if hostvars[item].kernel_arguments is defined %}'{{ hostvars[item].kernel_arguments }}'{% else %}''{% endif %} {% if hostvars[item].ramdisk_path is defined %}{{ script_directory.path }}/extra_config.img{% else %}''{%  endif %}"
 

--- a/ai-deploy-cluster-remoteworker/roles/prepare-environment/tasks/main.yml
+++ b/ai-deploy-cluster-remoteworker/roles/prepare-environment/tasks/main.yml
@@ -77,7 +77,7 @@
 - name: Create the small ISO and copy to desired path
   shell:
     chdir: "{{ script_directory.path }}"
-    cmd: "{{ script_directory.path }}/generate_rhcos_iso.sh {{ small_iso_path }}"
+    cmd: "{{ script_directory.path }}/generate_rhcos_iso.sh {{ temporary_path }}/small_{{ cluster_name }}.iso"
 
 - name: Check if filetranspiler exists
   shell: podman images | grep transpile | wc -l


### PR DESCRIPTION
This is the last bit that was superfluous. We can just
use temporary path and name the small iso with the
cluster name, and get rid of that extra setting.

Signed-off-by: Yolanda Robla <yroblamo@redhat.com>