### PR TITLE
Install missing packages

### DIFF
--- a/ai-deploy-cluster-remoteworker/roles/prepare-environment/tasks/main.yml
+++ b/ai-deploy-cluster-remoteworker/roles/prepare-environment/tasks/main.yml
@@ -1,14 +1,13 @@
 ---
-- name: Install podman
-  yum:
-    name: podman
-    state: present
-
-- name: install httpd
+- name: Install needed packages
   yum:
     name:
+      - podman
       - httpd
       - openssl-devel
+      - make
+      - libvirt-python3
+    state: present
 
 - name: Enable and start httpd
   systemd:


### PR DESCRIPTION
In order to run the playbook, several dependencies
are needed, and we were not installing those. Add the
missing packages to avoid the manual install

Fixes-issue: #32
Signed-off-by: Yolanda Robla <yroblamo@redhat.com>