### PR TITLE
Move temporary_path to global vars

### DIFF
--- a/ai-deploy-cluster-remoteworker/inventory/hosts.sample
+++ b/ai-deploy-cluster-remoteworker/inventory/hosts.sample
@@ -32,13 +32,13 @@ bridge_name=nm-bridge
 libvirt_uri="qemu:///system"
 need_racadm=true
 
+# path where to generate temporary directories
+temporary_path="/tmp/"
+
 [provisioner]
 # host from where the installation is performed
 localhost ansible_connection=local
 #<remote_ip> ansible_connection=ssh
-
-# path where to generate temporary directories
-temporary_path="/tmp/"
 
 [worker_nodes]
 worker-0.test-aut.cluster-testing name=worker_0 bmc_type=SuperMicro bmc_address=192.168.111.212 bmc_user="ADMIN" bmc_password="ADMIN" smb_host=192.168.111.1 smb_path=share ramdisk_path=/opt/network-config kernel_arguments="" final_iso_path=/home/share/ redeploy=false


### PR DESCRIPTION
It was currently just specified under provisioner,
but we are using this var in all the playbooks, so
move it to globals

Signed-off-by: Yolanda Robla <yroblamo@redhat.com>
Fixes-issue: #38