### PR TITLE
Add the ability to configure libvirt images path

### DIFF
--- a/ai-deploy-cluster-remoteworker/inventory/hosts.sample
+++ b/ai-deploy-cluster-remoteworker/inventory/hosts.sample
@@ -35,6 +35,9 @@ need_racadm=true
 # path where to generate temporary directories
 temporary_path=/tmp
 
+# optional: path where to store images for controlplane
+# libvirt_images_path=/var/lib/libvirt/images
+
 [provisioner]
 # host from where the installation is performed
 localhost ansible_connection=local

--- a/ai-deploy-cluster-remoteworker/roles/enroll-hosts/tasks/main.yml
+++ b/ai-deploy-cluster-remoteworker/roles/enroll-hosts/tasks/main.yml
@@ -16,7 +16,7 @@
   with_items: "{{ groups['master_nodes'] }}"
 
 - name: Create the qcow2 file
-  command: "qemu-img create -f qcow2 /var/lib/libvirt/images/{{ hostvars[item].name }}_{{ cluster_name }}.qcow2 50G"
+  command: "qemu-img create -f qcow2 {{ libvirt_images_path | default('/var/lib/libvirt/images') }}/{{ hostvars[item].name }}_{{ cluster_name }}.qcow2 50G"
   with_items: "{{ groups['master_nodes'] }}"
 
 - name: Create vm

--- a/ai-deploy-cluster-remoteworker/roles/enroll-hosts/templates/ai-vm.xml
+++ b/ai-deploy-cluster-remoteworker/roles/enroll-hosts/templates/ai-vm.xml
@@ -32,7 +32,7 @@
     <emulator>/usr/libexec/qemu-kvm</emulator>
     <disk type='file' device='disk'>
       <driver name='qemu' type='qcow2'/>
-      <source file='/var/lib/libvirt/images/{{ hostvars[item].name }}_{{ cluster_name }}.qcow2'/>
+      <source file='{{ libvirt_images_path | default('/var/lib/libvirt/images') }}/{{ hostvars[item].name }}_{{ cluster_name }}.qcow2'/>
       <target dev='hda' bus='ide'/>
       <address type='drive' controller='0' bus='0' target='0' unit='0'/>
     </disk>


### PR DESCRIPTION
It was currently hardcoded to /var/lib/libvirt/images,
but it can cause issues depending on the system.

Fixes-issue: #49