### PR TITLE
Add a default value for rootfs url

### DIFF
--- a/ai-deploy-cluster-remoteworker/inventory/hosts.sample
+++ b/ai-deploy-cluster-remoteworker/inventory/hosts.sample
@@ -12,7 +12,7 @@ kernel_arguments=""
 ai_iso_path=/opt/cached_disconnected_images
 
 # You can set your own rootfs image and store it under the same IP as above.
-rootfs_url=https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/4.6/latest/rhcos-live-rootfs.x86_64.img
+#rootfs_url=https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/4.6/latest/rhcos-live-rootfs.x86_64.img
 
 # should be same as the installer machine IP-address
 ai_url="http://192.168.112.199:8080"

--- a/ai-deploy-cluster-remoteworker/roles/modify-iso-day2/tasks/modify_iso_for_worker.yaml
+++ b/ai-deploy-cluster-remoteworker/roles/modify-iso-day2/tasks/modify_iso_for_worker.yaml
@@ -32,8 +32,26 @@
       remote_src: yes
   when: hostvars[item].ramdisk_path is defined
 
+- block:
+  - name: Read json with image versions
+    shell: cat "/opt/assisted-service-ztp/default_ocp_versions.json"
+    register: json_content
+
+  - name: Query for the right ISO according to the version
+    vars:
+      jsondata: "{{ json_content.stdout | from_json }}"
+      query_version: "\"{{ cluster_version }}\".rhcos_image"
+    set_fact:
+      rhcos_image: "{{ jsondata | json_query(query_version) }}"
+
+  - name: Manipulate the name, to add -rootfs suffix
+    set_fact:
+      default_rootfs_url: "{{ rhcos_image | regex_search('^http.*live', ignorecase=True) }}-rootfs.x86_64.img"
+      
+  when: (rootfs_url is not defined) or (rootfs|length==0)
+
 - name: Produce the final iso
   shell:
     chdir: "{{ script_directory.path }}"
-    cmd: "{{ script_directory.path }}/inject_config_files.sh {{ temporary_path }}/small_{{ cluster_name }}.iso {{ hostvars[item].final_iso_path }}/{{ hostvars[item].name }}.iso {{ ignition_url }}/{{ hostvars[item].name }} {{ rootfs_url }} {% if hostvars[item].kernel_arguments is defined %}'{{ hostvars[item].kernel_arguments }}'{% else %}''{% endif %} {% if hostvars[item].ramdisk_path is defined %}{{ script_directory.path }}/extra_config.img{% else %}''{%  endif %}"
+    cmd: "{{ script_directory.path }}/inject_config_files.sh {{ temporary_path }}/small_{{ cluster_name }}.iso {{ hostvars[item].final_iso_path }}/{{ hostvars[item].name }}.iso {{ ignition_url }}/{{ hostvars[item].name }} {% if rootfs_url is defined %}{{ rootfs_url }}{% else %}{{ default_rootfs_url }}{% endif %} {% if hostvars[item].kernel_arguments is defined %}'{{ hostvars[item].kernel_arguments }}'{% else %}''{% endif %} {% if hostvars[item].ramdisk_path is defined %}{{ script_directory.path }}/extra_config.img{% else %}''{%  endif %}"
 


### PR DESCRIPTION
When rootfs_url is not set, we can take the
cluster version and use a default var. This will
make it easier, for people not using local mirrors,
to just get the right rootfs for their version,
without having to investigate the final url.

Signed-off-by: Yolanda Robla <yroblamo@redhat.com>
Fixes-Issue: #54