### PR TITLE
Allow to define the role for each worker

### DIFF
--- a/ai-deploy-cluster-remoteworker/README.md
+++ b/ai-deploy-cluster-remoteworker/README.md
@@ -111,14 +111,14 @@ and Small ISO.
 
             $ aicli list hosts
 
-            +-------------------------------------------+-------------+--------------------------------------+---------------------------+--------+---------------+
-            |                    Host                   |   Cluster   |                  Id                  |           Status          |  Role  |       Ip      |
-            +-------------------------------------------+-------------+--------------------------------------+---------------------------+--------+---------------+
-            |     cnfde7.ptp.lab.eng.bos.redhat.com     | cnfde2-day2 | 3eedcafb-1558-1a71-5c35-afa338e0730a | added-to-existing-cluster | worker |  10.16.231.7  |
-            | dhcp16-231-115.ptp.lab.eng.bos.redhat.com |    cnfde2   | 6e01b4d4-8fa9-40b4-b477-8a4ac66c5826 |         installed         | master | 10.16.231.115 |
-            | dhcp16-231-152.ptp.lab.eng.bos.redhat.com |    cnfde2   | 1a7bf1ff-2c16-4653-8d8d-2e68f2311660 |         installed         | master | 10.16.231.152 |
-            | dhcp16-231-154.ptp.lab.eng.bos.redhat.com |    cnfde2   | e6d260ca-3a4b-4af6-8edd-478d90591f39 |         installed         | master | 10.16.231.154 |
-            +-------------------------------------------+-------------+--------------------------------------+---------------------------+--------+---------------+
+            +-------------------------------------------+-------------+--------------------------------------+---------------------------+-------------------+---------------+
+            |                    Host                   |   Cluster   |                  Id                  |           Status          |  Role             |       Ip      |
+            +-------------------------------------------+-------------+--------------------------------------+---------------------------+-------------------+---------------+
+            |     cnfde7.ptp.lab.eng.bos.redhat.com     | cnfde2-day2 | 3eedcafb-1558-1a71-5c35-afa338e0730a | added-to-existing-cluster | worker,worker-cnf |  10.16.231.7  |
+            | dhcp16-231-115.ptp.lab.eng.bos.redhat.com |    cnfde2   | 6e01b4d4-8fa9-40b4-b477-8a4ac66c5826 |         installed         | master            | 10.16.231.115 |
+            | dhcp16-231-152.ptp.lab.eng.bos.redhat.com |    cnfde2   | 1a7bf1ff-2c16-4653-8d8d-2e68f2311660 |         installed         | master            | 10.16.231.152 |
+            | dhcp16-231-154.ptp.lab.eng.bos.redhat.com |    cnfde2   | e6d260ca-3a4b-4af6-8edd-478d90591f39 |         installed         | master            | 10.16.231.154 |
+            +-------------------------------------------+-------------+--------------------------------------+---------------------------+-------------------+---------------+
 
     - You can download the kubeconfig of your cluster using the command below
 
@@ -149,8 +149,8 @@ and Small ISO.
 
             $ oc get nodes
 
-            NAME                                        STATUS   ROLES           AGE     VERSION
-            cnfde7.ptp.lab.eng.bos.redhat.com           Ready    worker          19h     v1.19.0+9f84db3
-            dhcp16-231-115.ptp.lab.eng.bos.redhat.com   Ready    master,worker   20h     v1.19.0+9f84db3
-            dhcp16-231-152.ptp.lab.eng.bos.redhat.com   Ready    master,worker   20h     v1.19.0+9f84db3
-            dhcp16-231-154.ptp.lab.eng.bos.redhat.com   Ready    master,worker   20h     v1.19.0+9f84db3
+            NAME                                        STATUS   ROLES               AGE     VERSION
+            cnfde7.ptp.lab.eng.bos.redhat.com           Ready    worker,worker-cnf   19h     v1.19.0+9f84db3
+            dhcp16-231-115.ptp.lab.eng.bos.redhat.com   Ready    master              20h     v1.19.0+9f84db3
+            dhcp16-231-152.ptp.lab.eng.bos.redhat.com   Ready    master              20h     v1.19.0+9f84db3
+            dhcp16-231-154.ptp.lab.eng.bos.redhat.com   Ready    master              20h     v1.19.0+9f84db3

--- a/ai-deploy-cluster-remoteworker/inventory/hosts.sample
+++ b/ai-deploy-cluster-remoteworker/inventory/hosts.sample
@@ -49,5 +49,5 @@ master_2 name=master_2 mac_address=52:54:00:55:f3:32
 master_3 name=master_3 mac_address=52:54:00:55:f3:33
 
 [worker_nodes]
-worker-0.test-aut.cluster-testing name=worker_0 bmc_type=SuperMicro bmc_address=192.168.111.212 bmc_user="ADMIN" bmc_password="ADMIN" smb_host=192.168.111.1 smb_path=share ramdisk_path=/opt/network-config kernel_arguments="" final_iso_path=/home/share/ redeploy=false
+worker-0.test-aut.cluster-testing name=worker_0 bmc_type=SuperMicro bmc_address=192.168.111.212 bmc_user="ADMIN" bmc_password="ADMIN" smb_host=192.168.111.1 smb_path=share ramdisk_path=/opt/network-config kernel_arguments="" final_iso_path=/home/share/ redeploy=false profile=worker-cnf
 worker-1 bmc_type=Dell name=worker_1 bmc_address=10.16.231.121 bmc_user="usr" bmc_password="pwd" ramdisk_path=/opt/network-config kernel_arguments="" final_iso_path=/opt/cached_disconnected_images redeploy=false

--- a/ai-deploy-cluster-remoteworker/roles/deploy-cluster-day2/tasks/main.yml
+++ b/ai-deploy-cluster-remoteworker/roles/deploy-cluster-day2/tasks/main.yml
@@ -5,6 +5,11 @@
       shell: "aicli update host $(aicli list hosts | grep {{ cluster_name }} | grep {{ item }} | awk '{print $6}') -P extra_args=[--copy-network]"
       with_items: "{{ groups['worker_nodes'] }}"
 
+    - name: For each worker, override the default mcp if it has a profile
+      shell: "aicli update host $(aicli list hosts | grep {{ cluster_name }} | grep {{ item }} | awk '{print $6}') -P mcp={{ hostvars[item].profile }}"
+      when: hostvars[item].profile is defined
+      with_items: "{{ groups['worker_nodes'] }}"
+
     - name: Install cluster
       shell: "aicli start cluster {{ cluster_name }}-day2"
   environment:


### PR DESCRIPTION
In order to avoid extra reboots, we can configure the nodes
to point to the right ignition file from the start, so they
get their machine config details from the moment zero. In
order to do that, we can add a setting called profile, and
we can configure the specific setting in assisted installer
to configure the right machine config pool for the node

Signed-off-by: Yolanda Robla <yroblamo@redhat.com>