### PR TITLE
Modify SDN to be OVN Kubernetes

### DIFF
--- a/ai-deploy-cluster-remoteworker/inventory/hosts.sample
+++ b/ai-deploy-cluster-remoteworker/inventory/hosts.sample
@@ -23,6 +23,7 @@ iso_url="http://192.168.112.199"
 cluster_name="test-aut"
 cluster_domain="cluster.testing"
 cluster_version="4.7"
+cluster_sdn="OpenShiftSDN" # if not set, defaults to OVNKubernetes
 
 # Make sure api_vip is mapped in your env DNS server to api.{cluster_name}.{cluster_domain} AND ingress_vip to *.apps.{cluster_name}.{cluster_domain}
 ingress_vip=192.168.112.195

--- a/ai-deploy-cluster-remoteworker/roles/create-cluster/tasks/main.yml
+++ b/ai-deploy-cluster-remoteworker/roles/create-cluster/tasks/main.yml
@@ -17,6 +17,18 @@
       delay: 5
       register: result
       until: result.rc == 0
+
+    - name: Retrieve cluster ID from name
+      shell: "aicli list cluster | grep {{ cluster_name }} | cut -d '|' -f3 | tr -d ' '"
+      register: cluster_id
+
+    - name: Set the right network type
+      uri:
+        url: "{{ ai_url }}/api/assisted-install/v1/clusters/{{ cluster_id.stdout }}/install-config"
+        method: PATCH        
+        body: '"{\"networking\": {\"networkType\": \"{{ cluster_sdn | default("OVNKubernetes") }}\"}}"'
+        body_format: json
+        status_code: 201
       
     - name: Generate the ISO for the cluster
       shell: "aicli create iso -P ssh_public_key='{{ ssh_public_key }}' {{ cluster_name }}"


### PR DESCRIPTION
For our RAN deployments, we need that the used SDN
is OVN Kubernetes, not the default OpenShiftSDN one
AI offers the possibility of configuring that, by patching
the install-config.yaml endpoint, so we are adding
this feature.

Signed-off-by: Yolanda Robla <yroblamo@redhat.com>