### PR TITLE
Alow to specify SDN in SNO

### DIFF
--- a/ai-deploy-cluster-singlenode/inventory/hosts.sample
+++ b/ai-deploy-cluster-singlenode/inventory/hosts.sample
@@ -6,6 +6,7 @@ ai_url="http://192.168.112.199:8080" # url where AI will be populated
 cluster_name="test-aut"
 cluster_domain="cluster.testing"
 cluster_version=4.8
+cluster_sdn="OpenShiftSDN"
 ssh_public_key="<your_ssh_key>"
 need_racadm=false # set to true if you use Dell
 final_iso_path=/home/share/ # path where to store the final ISO. Needs to point to the path of your SMB share/http server that populates the ISO

--- a/ai-deploy-cluster-singlenode/roles/create-cluster/tasks/main.yml
+++ b/ai-deploy-cluster-singlenode/roles/create-cluster/tasks/main.yml
@@ -14,9 +14,17 @@
     - name: Create new AI cluster
       shell: "aicli create cluster -P pull_secret={{ tempfile_pullsecret.path }} -P base_dns_domain={{ cluster_domain }} -P ssh_public_key='{{ ssh_public_key }}' -P high_availability_mode=None -P openshift_version='{{ cluster_version }}' {{ cluster_name }}"
 
-    - name: Retrieve the cluster ID
-      shell: "aicli list clusters | grep test-aut  | cut -d '|' -f 3"
+    - name: Retrieve cluster ID from name
+      shell: "aicli list cluster | grep {{ cluster_name }} | cut -d '|' -f3 | tr -d ' '"
       register: cluster_id
+
+    - name: Set the right network type
+      uri:
+        url: "{{ ai_url }}/api/assisted-install/v1/clusters/{{ cluster_id.stdout }}/install-config"
+        method: PATCH        
+        body: '"{\"networking\": {\"networkType\": \"{{ cluster_sdn | default("OVNKubernetes") }}\"}}"'
+        body_format: json
+        status_code: 201
 
     - name: Create a temporary file for the template
       tempfile:


### PR DESCRIPTION
We need to deploy with OVNKubernetes, so se need to
patch the API to use that, instead of default OpenShiftSDN

Signed-off-by: Yolanda Robla <yroblamo@redhat.com>