### PR TITLE
Fix missing inventory setting

### DIFF
--- a/ai-deploy-cluster-remoteworker/inventory/hosts.sample
+++ b/ai-deploy-cluster-remoteworker/inventory/hosts.sample
@@ -27,6 +27,11 @@ need_racadm=true
 # path where to generate temporary directories
 temporary_path=/tmp
 
+# path where to copy the ISO
+# if using httpd for virtual media, path to the http server for
+# the images. If using samba, path to the samba share
+final_iso_path=/var/www/html
+
 # optional: path where to store images for controlplane
 # libvirt_images_path=/var/lib/libvirt/images
 #
@@ -46,5 +51,5 @@ master_3 name=master_3 mac_address=52:54:00:55:f3:33
 
 [worker_nodes]
 # only set ip if you need to embed static network. It needs to match with the nmstate config
-worker-0.test-aut.cluster-testing name=worker_0 bmc_type=SuperMicro bmc_address=192.168.111.212 bmc_user="ADMIN" bmc_password="ADMIN" smb_host=192.168.111.1 smb_path=share ip=<host_ip> hostname=<hostname> redeploy=false profile=worker-cnf
+worker-0.test-aut.cluster.testing name=worker_0 bmc_type=SuperMicro bmc_address=192.168.111.212 bmc_user="ADMIN" bmc_password="ADMIN" smb_host=192.168.111.1 smb_path=share ip=<host_ip> hostname=<hostname> redeploy=false profile=worker-cnf
 worker-1 bmc_type=Dell name=worker_1 bmc_address=10.16.231.121 bmc_user="usr" bmc_password="pwd" 

--- a/ai-deploy-cluster-remoteworker/roles/add-remote-workers/tasks/main.yml
+++ b/ai-deploy-cluster-remoteworker/roles/add-remote-workers/tasks/main.yml
@@ -20,7 +20,6 @@
     bmc_user: "{{ hostvars[item].bmc_user }}"
     bmc_password: "{{ hostvars[item].bmc_password }}"
     bmc_address: "{{ hostvars[item].bmc_address }}"
-    iso_url: "{{ hostvars[item].iso_url }}"
   when: hostvars[item].bmc_type == "Dell"
   with_items: "{{ groups['worker_nodes'] }}"
 


### PR DESCRIPTION
When enrolling the remote workers the final_iso_path
setting was missing in the sample inventory, and also
the path was not incorrectly set for Dell.

Signed-off-by: Yolanda Robla <yroblamo@redhat.com>