### PR TITLE
Match workload partitioning name changes in kubelet

### DIFF
--- a/ai-deploy-cluster-singlenode/roles/enable-workload-partitioning/templates/02-master-workload-partitioning.yaml
+++ b/ai-deploy-cluster-singlenode/roles/enable-workload-partitioning/templates/02-master-workload-partitioning.yaml
@@ -21,6 +21,6 @@ spec:
           source: data:text/plain;charset=utf-8;base64,{{ lookup('template', 'templates/kubelet.conf', convert_data=False) | string | b64encode}}
         mode: 420
         overwrite: true
-        path: /etc/kubernetes/workload-pinning
+        path: /etc/kubernetes/openshift-workload-pinning
         user:
           name: root


### PR DESCRIPTION
The filename of the drop-in configuration we need to add to enable workload
partitioning has changed (https://github.com/openshift/enhancements/pull/726),
so we follow.