### PR TITLE
Add release mirror parameters

### DIFF
--- a/ai-deploy-cluster-singlenode/inventory/hosts.sample
+++ b/ai-deploy-cluster-singlenode/inventory/hosts.sample
@@ -13,6 +13,13 @@ cluster_name="test-aut"
 cluster_domain="cluster.testing"
 cluster_sdn="OpenShiftSDN"
 
+# Registry mirror cert file full path and image content sources.
+# If not using release mirror, leave undefined
+# registry_mirror_cert='/opt/registry/certs/domain.crt'
+# Image content sources in yaml format as received from "oc adm release mirror" command output
+image_content_sources = '/root/imageContentSources.yaml'
+
+
 # OpenShift versions that will be used by AI 
 # Be careful with changing rhcos_base_iso without changing the equivalent cluster_version.
 cluster_version=4.8

--- a/common-roles/create-cluster/tasks/main.yml
+++ b/common-roles/create-cluster/tasks/main.yml
@@ -1,4 +1,18 @@
 ---
+- name: Handle release mirror 
+  block:
+  - name: Get local registry certificate (will fail if the file is not there)
+    set_fact:
+      registry_mirror_certificate: "{{ lookup('file', registry_mirror_cert, rstrip=False) }}"
+  - name: Get image content sources
+    set_fact:
+      image_content_sources: "{{ lookup('file', image_content_sources, rstrip=False) | from_yaml | to_json }}"
+  when: registry_mirror_cert is defined
+
+- name: populate the install config patch
+  set_fact:
+    instal_cfg_patch: "{{ lookup('template', 'install-config.json.j2') |to_json }}"
+
 - name: Create a temporary file
   tempfile:
     state: file
@@ -22,13 +36,15 @@
       shell: "aicli list cluster | grep {{ cluster_name_var }} | cut -d '|' -f3 | tr -d ' '"
       register: cluster_id
 
-    - name: Set the right network type
+    - name: Patch the install-config
       uri:
         url: "{{ ai_url }}/api/assisted-install/v1/clusters/{{ cluster_id.stdout }}/install-config"
         method: PATCH
-        body: '"{\"networking\": {\"networkType\": \"{{ cluster_sdn | default("OVNKubernetes") }}\"}}"'
+        headers:
+          Content-Type: application/json
+          accept: application/json
+        body: "{{ instal_cfg_patch }}"
         body_format: json
         status_code: 201
   environment:
     AI_URL: "{{ ai_url }}"
-

--- a/common-roles/create-cluster/templates/install-config.json.j2
+++ b/common-roles/create-cluster/templates/install-config.json.j2
@@ -1,0 +1,1 @@
+{ {% if registry_mirror_cert is defined %} "additionalTrustBundle":{{ registry_mirror_certificate | to_json }},{{ image_content_sources }},{% endif %}"networking":{"networkType":"{{ cluster_sdn | default("OVNKubernetes") }}" }}


### PR DESCRIPTION
This commit adds install-config patches in case we want to install the cluster from a disconnected registry