### PR TITLE
Change order of onprem-vars

### DIFF
--- a/common-roles/install-assisted-installer/tasks/main.yml
+++ b/common-roles/install-assisted-installer/tasks/main.yml
@@ -6,12 +6,6 @@
     update: yes
     force: yes
 
-- name: Add env var to file if does not exist
-  lineinfile:
-    path: /opt/assisted-service-ztp/onprem-environment
-    line: "{{ item }}"
-  with_items: "{{ onprem_vars }}"
-
 - name: Clean the pod
   shell: "podman pod rm -f assisted-installer"
   ignore_errors: yes
@@ -33,6 +27,12 @@
   shell: "curl {{ rhcos_base_iso }} -o livecd.iso"
   args:
     chdir: "/opt/assisted-service-ztp"
+
+- name: Add env var to file if does not exist
+  lineinfile:
+    path: /opt/assisted-service-ztp/onprem-environment
+    line: "{{ item }}"
+  with_items: "{{ onprem_vars }}"
 
 - name: Start the assisted installer service
   shell: "ASSISTED_TAG={{ assisted_tag | default('latest') }} make deploy-onprem"


### PR DESCRIPTION
The task is using rhcos_base_iso, that is defined
on tasks executed later, so it doesn't have the
reference. Changing the order to fix it.