### PR TITLE
Update crio.conf template for Workload Partitioning

### DIFF
--- a/ai-deploy-cluster-singlenode/roles/enable-workload-partitioning/templates/crio.conf
+++ b/ai-deploy-cluster-singlenode/roles/enable-workload-partitioning/templates/crio.conf
@@ -1,4 +1,4 @@
 [crio.runtime.workloads.{{ management_workload_name }}]
 activation_annotation = "target.workload.openshift.io/{{ management_workload_name }}"
 annotation_prefix = "resources.workload.openshift.io"
-resources = { "cpushares" = "", "cpuset" = "{{ management_workload_cpuset }}" }
+resources = { "cpushares" = 0, "cpuset" = "{{ management_workload_cpuset }}" }


### PR DESCRIPTION
Schema for the workload partitioning has changed. The cpushares value must be an integer.
Signed-off-by: Ian Miller <imiller@redhat.com>