### PR TITLE
Set the assisted-service version to v1.0.18.3

### DIFF
--- a/ai-deploy-cluster-singlenode/inventory/hosts.sample
+++ b/ai-deploy-cluster-singlenode/inventory/hosts.sample
@@ -27,8 +27,8 @@ support_level="beta"
 ai_version="HEAD"
 
 # Set as "latest" for latest quay image
-# assisted_tag=stable.12.03.2021-07.23
-assisted_tag=latest
+# assisted_tag=v1.0.18.3
+assisted_tag=v1.0.18.3
 
 ### BMC variables. Set according to your server' hardware ###
 bmc_address=10.46.61.142


### PR DESCRIPTION
For SNO, this version works (in the "classic" mode) but also includes the fix
so that UEFI boot works as well.

Signed-off-by: Jim Ramsay <jramsay@redhat.com>