### PR TITLE
Remove need for Red Hat credentials in inventory.

### DIFF
--- a/common-roles/offline-mirror-olm/tasks/main.yml
+++ b/common-roles/offline-mirror-olm/tasks/main.yml
@@ -18,6 +18,7 @@
   ansible.builtin.copy:
     content: "{{ pull_secret }}"
     dest: "{{ temporary_directory.path }}/pull_secret"
+  register: pull_secret_loc
 
 - name: Download oc binary
   ansible.builtin.unarchive:
@@ -34,7 +35,7 @@
     dest: "{{ temporary_directory.path }}/{{ item | replace('.j2', '') }}"
     mode: 0755
   vars:
-    pull_secret_path: "{{ temporary_directory.path }}/pull_secret"
+    pull_secret_path: "{{ pull_secret_loc.dest }}"
     binary_path: "/usr/bin/"
     provisioner_cluster_registry_var: "{% if provisioner_cluster_registry is defined and provisioner_cluster_registry|length > 0 %}{{ provisioner_cluster_registry }}{% else %}{{ provisioner_cluster_name }}-installer.{{ provisioner_cluster_domain }}:5000{% endif %}"
     provisioner_cluster_registry_user: dummy
@@ -54,6 +55,7 @@
     executable: /bin/bash
   environment:
     KUBECONFIG: "{{ temporary_path }}/kubeconfig"
+    REGISTRY_AUTH_FILE: "{{ pull_secret_loc.dest }}"
 
 - name: Create catalog source
   ansible.builtin.shell:

--- a/common-roles/offline-mirror-olm/templates/offline-operator-mirror.sh.j2
+++ b/common-roles/offline-mirror-olm/templates/offline-operator-mirror.sh.j2
@@ -24,8 +24,6 @@ export MARKETPLACE_OP_INDEX="registry.redhat.io/redhat-marketplace-index:v${OCP_
 
 podman_login() {
 podman login --tls-verify=false $LOCAL_REGISTRY --username {{ provisioner_cluster_registry_user }} --password {{ provisioner_cluster_registry_password }}
-podman login registry.redhat.io --username {{ redhat_subscription_user }} --password {{ redhat_subscription_password }}
-
 }
 
 podman_login

--- a/install-ai-operator/inventory/hosts.sample
+++ b/install-ai-operator/inventory/hosts.sample
@@ -1,9 +1,8 @@
 [all:vars]
 
+# Pull secret must include all necessary auth, including registry.redhat.io
 pull_secret='<pull_secret_var>'
 ssh_public_key="<ssh_public_key>'
-redhat_subscription_user=<redhat_subscription_user>
-redhat_subscription_password=<redhat_subscription_pass>
 
 temporary_path=/tmp
 


### PR DESCRIPTION
Update the scripts to use registry.redhat.io credentials embedded in the
pull secret instead of requiring explicit credentials in the inventory
file.

Signed-off-by: Ian Miller <imiller@redhat.com>