### PR TITLE
Fix ose reference

### DIFF
--- a/common-roles/offline-mirror-olm/templates/offline-operator-mirror.sh.j2
+++ b/common-roles/offline-mirror-olm/templates/offline-operator-mirror.sh.j2
@@ -35,7 +35,6 @@ oc patch OperatorHub cluster --type json -p '[{"op": "add", "path": "/spec/disab
 opm index prune \
 -f registry.redhat.io/redhat/redhat-operator-index:v${OCP_RELEASE} \
 -p local-storage-operator \
--i registry.redhat.io/openshift4/ose-operator-registry:v${OCP_RELEASE} \
 -t $LOCAL_REGISTRY/olm/redhat-operator-index:v${OCP_RELEASE}
 
 REGISTRY_AUTH_FILE= podman push --tls-verify=false $LOCAL_REGISTRY/olm/redhat-operator-index:v${OCP_RELEASE}


### PR DESCRIPTION
This is no longer used, and is causing the mirroring
to fail, as latest version of this is 4.6