### PR TITLE
Add missing ignition override

### DIFF
--- a/create-cluster-sno/inventory/hosts.sample
+++ b/create-cluster-sno/inventory/hosts.sample
@@ -23,6 +23,8 @@ machine_network_sufix=64
 service_network_cidr=1001:db7::
 service_network_sufix=64
 ssh_pubkey="<ssh key>"
+# uncomment that to inject extra ign customizations
+#ignition_config_override='{"ignition": {"version": "3.1.0"}, "storage": {"files": [{"path": "/etc/someconfig", "contents": {"source": "data:text/plain;base64,aGVscGltdHJhcHBlZGluYXN3YWdnZXJzcGVj"}}]}}'
 
 ##############################
 # Extra installation manifests. Any manifests in this path will be

--- a/create-cluster-sno/templates/infra_env.yaml.j2
+++ b/create-cluster-sno/templates/infra_env.yaml.j2
@@ -18,6 +18,9 @@ spec:
     {% if https_proxy is defined and https_proxy|length > 0 %}httpsProxy: {{ https_proxy }}{% endif %}
 {% endif %}
   sshAuthorizedKey: '{{ ssh_pubkey }}'
+{% if ignition_config_override is defined and ignition_config_override|length > 0 %}
+  ignitionConfigOverride: '{{ ignition_config_override }}'
+{% endif %}
 {% if nmstate_path is defined %}
   nmStateConfigLabelSelector:
     matchLabels:


### PR DESCRIPTION
Assisted Service allows ignition configuration
for the initial images. Add the ability to inject it.

Signed-off-by: Yolanda Robla <yroblamo@redhat.com>